### PR TITLE
Allow access to 'require()' in unit tests

### DIFF
--- a/runner.nw/package.json
+++ b/runner.nw/package.json
@@ -2,5 +2,6 @@
   "name": "karma-runner",
   "main": "index.html",
   "window": {
-  }
+  },
+  "node-remote": "<local>"
 }


### PR DESCRIPTION
One of the benefits of using this runner is to enable the full node-webkit environment, so that the unit tests have access to `require()`. 

Enabling `node-remote` turns on the node api to locally-served files.

(Sorry if all these pull requests are annoying. =)
