### PR TITLE
Make things work in tandem with windows nodewebkit

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ NodeWebkitBrowser.prototype = {
   DEFAULT_CMD: {
     linux: path.normalize(__dirname + '/../.bin/nodewebkit'),
     darwin: path.normalize(__dirname + '/../nodewebkit/nodewebkit/node-webkit.app/Contents/MacOS/node-webkit'),
-    win32: path.normalize(__dirname + '/../.bin/nodewebkit.exe')
+    win32: path.normalize(__dirname + '/../nodewebkit/nodewebkit/nw.exe')
   },
 
   ENV_CMD: 'NODEWEBKIT_BIN'


### PR DESCRIPTION
NPM nodewebkit module includes windows version with that path. Does this look good to you? Seems to work for us.
