### PR TITLE
updated default darwin path

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ NodeWebkitBrowser.prototype = {
 
   DEFAULT_CMD: {
     linux: path.normalize(__dirname + '/../.bin/nodewebkit'),
-    darwin: path.normalize(__dirname + '/../nodewebkit/nodewebkit/node-webkit.app/Contents/MacOS/node-webkit'),
+    darwin: path.normalize(__dirname + '/../nodewebkit/nodewebkit/Contents/MacOS/node-webkit'),
     win32: path.normalize(__dirname + '/../nodewebkit/nodewebkit/nw.exe')
   },
 


### PR DESCRIPTION
Installing `nodewebkit` now puts the binary at this new path.
