### PR TITLE
Kill child processes created by NodeWebkit Chromedriver

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "ncp": "~0.5.0",
     "async": "~0.2.10",
     "merge": "~1.1.2",
-    "nodewebkit": "^0.8.5"
+    "nodewebkit": "^0.8.5",
+    "ps-tree": "0.0.3"
   },
   "peerDependencies": {
     "karma": ">=0.9"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ncp": "~0.5.0",
     "async": "~0.2.10",
     "merge": "~1.1.2",
-    "nodewebkit": "^0.8.5",
+    //"nodewebkit": "^0.8.5",
     "ps-tree": "0.0.3"
   },
   "peerDependencies": {
@@ -48,6 +48,10 @@
     {
       "name": "Michal Charemza",
       "email": "michalcharemza@gmail.com"
+    },
+    {
+      "name": "Denny Lim",
+      "email": "hi.iamdeny@gmail.com"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "ncp": "~0.5.0",
     "async": "~0.2.10",
     "merge": "~1.1.2",
-    //"nodewebkit": "^0.8.5",
     "ps-tree": "0.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
All the children processes should be killed together.
